### PR TITLE
Fixidentifier

### DIFF
--- a/papas/data/identifier.py
+++ b/papas/data/identifier.py
@@ -190,6 +190,7 @@ class Identifier(long):
         _id=count(1)
         print "Identifier reset"
         print "Identifier value of count is", cls._id.next()
+        cls._id=count(1)
         pdebugger.info("reset ID")
         return    
 

--- a/papas/data/identifier.py
+++ b/papas/data/identifier.py
@@ -67,7 +67,8 @@ class Identifier(long):
             assert(abs(Identifier.get_value(uid) - value) < abs(value) * 10 ** -6)
         assert (Identifier.get_type(uid) == type)
         assert (Identifier.get_subtype(uid) == subtype)
-
+        if x >= 2**(21 -1):
+            raise ValueError('identifer unique counter id has exceeded maximum value allowed')
         return uid
 
     @staticmethod      
@@ -172,13 +173,24 @@ class Identifier(long):
         s = struct.pack('>l', bitvalue)
         return struct.unpack('>f', s)[0]	
 
+    #@staticmethod
+    #def reset():
+        #''' Resets the internal Identifier counter to 1
+        #'''
+        #_id=count(1)
+        #print _id.next()
+        #pdebugger.info("reset ID")
+        #return
+    
     @classmethod
     def reset(cls):
         ''' Resets the internal Identifier counter to 1
         '''
         cls._id=count(1)
+        _id=count(1)
+        print cls._id.next()
         pdebugger.info("reset ID")
-        return
+        return    
 
 
 if __name__ == '__main__':

--- a/papas/data/identifier.py
+++ b/papas/data/identifier.py
@@ -172,27 +172,18 @@ class Identifier(long):
         @param bitvalue: bitvalue'''
         s = struct.pack('>l', bitvalue)
         return struct.unpack('>f', s)[0]	
-
-    #@staticmethod
-    #def reset():
-        #''' Resets the internal Identifier counter to 1
-        #'''
-        #_id=count(1)
-        #print _id.next()
-        #pdebugger.info("reset ID")
-        #return
+    
     
     @classmethod
     def reset(cls):
         ''' Resets the internal Identifier counter to 1
         '''
-        cls._id=count(1)
-        _id=count(1)
-        print "Identifier reset"
-        print "Identifier value of count is", cls._id.next()
+        #cls._id=count(1)
+        #print "Identifier reset"
+        #print "Identifier value of count is", cls._id.next()
         cls._id=count(1)
         pdebugger.info("reset ID")
-        return    
+        return
 
 
 if __name__ == '__main__':

--- a/papas/data/identifier.py
+++ b/papas/data/identifier.py
@@ -188,7 +188,8 @@ class Identifier(long):
         '''
         cls._id=count(1)
         _id=count(1)
-        print cls._id.next()
+        print "Identifier reset"
+        print "Identifier value of count is", cls._id.next()
         pdebugger.info("reset ID")
         return    
 

--- a/papas/data/papasevent.py
+++ b/papas/data/papasevent.py
@@ -42,6 +42,7 @@ class PapasEvent(Event):
     
     def __init__(self, iEv):
         super(PapasEvent, self).__init__(iEv)
+        Identifier.reset()
         self.collections = dict()
         self.history = dict()
         

--- a/papas/data/test_historyhelper.py
+++ b/papas/data/test_historyhelper.py
@@ -17,7 +17,6 @@ class TestHistoryHelper(unittest.TestCase):
         tracks = dict()
         mixed = dict()
         
-        Identifier.reset()
         for i in range(0, 2):
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
             ecals[uid] = uid

--- a/papas/data/test_papasevent.py
+++ b/papas/data/test_papasevent.py
@@ -31,7 +31,7 @@ class TestPapasEvent(unittest.TestCase):
    
     def test_papasevent(self):
         
-        Identifier.reset()
+        Identifier.reset() #this line should not be needed
         papasevent = PapasEvent(0)
         
         ecals = dict()

--- a/papas/data/test_papasevent.py
+++ b/papas/data/test_papasevent.py
@@ -7,16 +7,23 @@ from papasevent import PapasEvent
 class TestPapasEvent(unittest.TestCase):
    
     def test_papasevent(self):
+        uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
+        uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
+        uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
+        uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
+        #Identifier.reset()
         papasevent = PapasEvent(0)
         
         ecals = dict()
         tracks = dict()
         mixed = dict()
-        Identifier.reset()
-        for i in range(0, 2):
+
+        for i in range(0, 2):         
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
+            print Identifier.pretty(uid)
             ecals[uid] = uid
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 's', 4.5)
+            print Identifier.pretty(uid)
             tracks[uid] = uid            
         
         lastid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 3)
@@ -38,6 +45,8 @@ class TestPapasEvent(unittest.TestCase):
         self.assertTrue( len(papasevent.get_collection('et'))  == 3 )
         
         #check get_object
+        print Identifier.pretty(papasevent.get_object(lastid))
+        print Identifier.pretty(lastid)
         self.assertTrue( Identifier.pretty(papasevent.get_object(lastid))  == 'et5' )
         self.assertTrue( papasevent.get_object(499)  is None )       
 

--- a/papas/data/test_papasevent.py
+++ b/papas/data/test_papasevent.py
@@ -12,7 +12,8 @@ class TestPapasEvent(unittest.TestCase):
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5) 
             print Identifier.pretty(uid)
             
-#calls identifer.reset but it does not reset            
+#calls identifer.reset but it does not reset  
+            print "rest identifier via papasevent"
             papasevent = PapasEvent(0)
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
             print Identifier.pretty(uid)
@@ -20,25 +21,22 @@ class TestPapasEvent(unittest.TestCase):
             print Identifier.pretty(uid)
             
 #this does reset
+            print "rest identifier direct"
             Identifier.reset()
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
             print Identifier.pretty(uid)
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5) 
             print Identifier.pretty(uid)
             pass
-                    
-            
    
     def test_papasevent(self):
-        
-        Identifier.reset() #this line should not be needed
+        #removed identifer.reset and this breaks the test (see above for simplified case)
         papasevent = PapasEvent(0)
-        
         ecals = dict()
         tracks = dict()
         mixed = dict()
 
-        for i in range(0, 2):         
+        for i in range(0, 2):
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
             ecals[uid] = uid
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 's', 4.5)

--- a/papas/data/test_papasevent.py
+++ b/papas/data/test_papasevent.py
@@ -5,13 +5,33 @@ from identifier import Identifier
 from papasevent import PapasEvent 
 
 class TestPapasEvent(unittest.TestCase):
+    
+    def test_broken(self):
+            uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
+            print Identifier.pretty(uid)
+            uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5) 
+            print Identifier.pretty(uid)
+            
+#calls identifer.reset but it does not reset            
+            papasevent = PapasEvent(0)
+            uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
+            print Identifier.pretty(uid)
+            uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5) 
+            print Identifier.pretty(uid)
+            
+#this does reset
+            Identifier.reset()
+            uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
+            print Identifier.pretty(uid)
+            uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5) 
+            print Identifier.pretty(uid)
+            pass
+                    
+            
    
     def test_papasevent(self):
-        uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
-        uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
-        uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
-        uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
-        #Identifier.reset()
+        
+        Identifier.reset()
         papasevent = PapasEvent(0)
         
         ecals = dict()
@@ -20,10 +40,8 @@ class TestPapasEvent(unittest.TestCase):
 
         for i in range(0, 2):         
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 4.5)
-            print Identifier.pretty(uid)
             ecals[uid] = uid
             uid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 's', 4.5)
-            print Identifier.pretty(uid)
             tracks[uid] = uid            
         
         lastid = Identifier.make_id(Identifier.PFOBJECTTYPE.ECALCLUSTER, 't', 3)
@@ -45,8 +63,6 @@ class TestPapasEvent(unittest.TestCase):
         self.assertTrue( len(papasevent.get_collection('et'))  == 3 )
         
         #check get_object
-        print Identifier.pretty(papasevent.get_object(lastid))
-        print Identifier.pretty(lastid)
         self.assertTrue( Identifier.pretty(papasevent.get_object(lastid))  == 'et5' )
         self.assertTrue( papasevent.get_object(499)  is None )       
 

--- a/test/analysis_ee_ZH_cfg.py
+++ b/test/analysis_ee_ZH_cfg.py
@@ -258,7 +258,6 @@ if __name__ == '__main__':
     random.seed(0xdeadbeef)
 
     def process(iev=None):
-        Identifier.reset() #todo move elsewhere
         if iev is None:
             iev = loop.iEvent
         loop.process(iev)

--- a/test/create_papas_display_cfg.py
+++ b/test/create_papas_display_cfg.py
@@ -301,7 +301,6 @@ if __name__ == '__main__':
     random.seed(0xdeadbeef)
 
     def process(iev=None):
-        Identifier.reset()
         if iev is None:
             iev = loop.iEvent
         loop.process(iev)

--- a/test/test_analysis_ee_Z.py
+++ b/test/test_analysis_ee_Z.py
@@ -48,8 +48,8 @@ if context.name == 'fcc':
             rootfile = '/'.join([self.outdir,
                                 'heppy.analyzers.GlobalEventTreeProducer.GlobalEventTreeProducer_1/tree.root'])
             mean, sigma = plot(rootfile)
-            self.assertAlmostEqual(mean, 90.13, 1)
-            self.assertAlmostEqual(sigma, 10.54, 1)
+            self.assertAlmostEqual(mean, 90.36, 1)
+            self.assertAlmostEqual(sigma, 10.78, 1)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
OK, here we go. Added Identifer.reset to papasevent.

I double checked and the Identifier.reset was at most only being called at the start of a run, not once per event. Now it gets called each event.
Thankyou