### PR TITLE
removing call to make_id from fcc.particle

### DIFF
--- a/analyzers/PapasSim.py
+++ b/analyzers/PapasSim.py
@@ -82,7 +82,6 @@ class PapasSim(Analyzer):
     def build_collections_and_history(self, papasevent, sim_particles):  
         #todo this should be integrated into the simulator in the future
         simulated_particles = dict()
-        gen_stable_particles = dict()
         tracks = dict()
         smeared_tracks=dict()
         smeared_hcals = dict()
@@ -97,11 +96,6 @@ class PapasSim(Analyzer):
             uid = ptc.uniqueid
             simulated_particles[uid] = ptc
             history[uid] = Node(uid)
-            gen_id = ptc.gen_ptc.uniqueid
-            gen_stable_particles[gen_id] = ptc.gen_ptc
-            history[gen_id] = Node(gen_id)
-            history[gen_id].add_child(history[uid])
-    
             if ptc.track:
                 track_id = ptc.track.uniqueid
                 true_tracks[track_id] = ptc.track
@@ -134,7 +128,6 @@ class PapasSim(Analyzer):
                                 history[clust.uniqueid].add_child(history[smclust.uniqueid])
                             
         papasevent.add_collection(simulated_particles)
-        papasevent.add_collection(gen_stable_particles)
         papasevent.add_collection(true_tracks)
         papasevent.add_collection(smeared_tracks)
         papasevent.add_collection(smeared_hcals)

--- a/papas/simulator.py
+++ b/papas/simulator.py
@@ -268,8 +268,6 @@ cannot be extrapolated to : {det}\n'''.format(ptc=ptc,
 
         #newsort
         # import pdb; pdb.set_trace()
-        for gen_ptc in sorted(ptcs, key=lambda ptc: ptc.uniqueid):
-            pdebugger.info(str('{}'.format(gen_ptc)))
         for gen_ptc in ptcs:
             ptc = pfsimparticle(gen_ptc)
             if ptc.pdgid() == 22:

--- a/particles/fcc/particle.py
+++ b/particles/fcc/particle.py
@@ -2,7 +2,6 @@ from heppy.particles.particle import Particle as BaseParticle
 from vertex import Vertex
 from pod import POD
 from ROOT import TLorentzVector
-from heppy.papas.data.identifier import Identifier
 from heppy.utils.pdebug import pdebugger
 import copy
 
@@ -10,8 +9,6 @@ class Particle(BaseParticle, POD):
     
     def __init__(self, fccobj):
         super(Particle, self).__init__(fccobj)
-        self.uniqueid=Identifier.make_id(Identifier.PFOBJECTTYPE.PARTICLE, 'g')
-        self.uniqueid=Identifier.make_id(Identifier.PFOBJECTTYPE.PARTICLE)
         self._charge = fccobj.core().charge
         self._pid = fccobj.core().pdgId
         self._status = fccobj.core().status
@@ -44,14 +41,5 @@ class Particle(BaseParticle, POD):
         return tmp.format(
             pdgid =pid,
             e = self.e()        
-        )    
-    
-    def __str__(self):
-        mainstr =  super(Particle, self).__str__()
-        idstr = '{pretty:6}:{uid}'.format(
-            pretty = Identifier.pretty(self.uniqueid),
-            uid = self.uniqueid)
-        fields = mainstr.split(':')
-        fields.insert(1, idstr)
-        return ':'.join(fields)     
+        )
 


### PR DESCRIPTION
Fix to fcc Particle to avoid using Identifier class.